### PR TITLE
Create Triangulation newtype and improve triangulation tests

### DIFF
--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -68,6 +68,11 @@ impl Polygon {
     }
     
     pub fn double_area(&self) -> i32 {
+        // Computes double area of the polygon.
+        //
+        // NOTE: This is computing double area so that I can stick to
+        // i32 return types in this preliminary implementation and
+        // not worry about floating point issues.
         let mut area = 0;
         let anchor = self.vertex_map.anchor();
         for v1 in self.vertex_map.values() {
@@ -78,6 +83,11 @@ impl Polygon {
     }
 
     pub fn double_area_from_triangulation(&self, triangulation: &Triangulation) -> i32 {
+        // Computes double area from a triangulation as the sum of
+        // the double area of the individual triangles that 
+        // constitute the triangulation.
+        // 
+        // This value should always be exactly equal to `self.double_area()`.
         let mut area = 0;
         for ids in triangulation.iter() {
             let v1 = self.vertex_map.get(&ids.0);

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -225,6 +225,8 @@ mod tests {
     }
 
     #[rstest]
+    #[case(right_triangle(), 1, 12)]
+    #[case(square_4x4(), 2, 32)]
     #[case(polygon_2(), 16, 466)]
     fn test_triangulation(
         #[case] polygon: Polygon, 

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -215,7 +215,7 @@ mod tests {
     #[case(square_4x4(), 4)]
     #[case(polygon_1(), 6)]
     #[case(polygon_2(), 18)]
-    fn test_edges_square(#[case] polygon: Polygon, #[case] num_edges: usize) {
+    fn test_edges(#[case] polygon: Polygon, #[case] num_edges: usize) {
         let mut expected_edges = HashSet::new();
         for i in 0usize..num_edges {
             expected_edges.insert((VertexId::from(i), VertexId::from((i + 1) % num_edges)));

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -225,12 +225,16 @@ mod tests {
     }
 
     #[rstest]
-    fn test_triangulation(polygon_2: Polygon) {
-        let triangulation = polygon_2.triangulation();
-        assert_eq!(triangulation.len(), 16);
+    #[case(polygon_2(), 16, 466)]
+    fn test_triangulation(
+        #[case] polygon: Polygon, 
+        #[case] expected_num_triangles: usize, 
+        #[case] expected_double_area: i32,
+    ) {
+        let triangulation = polygon.triangulation();
+        assert_eq!(triangulation.len(), expected_num_triangles);
 
-        let double_area = polygon_2.double_area();
-        let triangulation_double_area = polygon_2.double_area_from_triangulation(&triangulation);
-        assert_eq!(double_area, triangulation_double_area);
+        let triangulation_double_area = polygon.double_area_from_triangulation(&triangulation);
+        assert_eq!(triangulation_double_area, expected_double_area);
     }
 }


### PR DESCRIPTION
Changes the return type of `triangulation` to better support tests and visualizations.

- Adds `TriangleVertexIds` newtype to encapsulate a named 3-tuple of vertex IDs
- Adds `Triangulation` newtype wrapping a `HashSet<TriangleVertexIds>`
- Changes return type of `Polygon.triangulation` to `Triangulation`
- Fixes `triangulation` given the new interpretation of what a triangulation is to also add the last triangle before returning
- Adds a `double_area_from_triangulation` function to `Polygon` to provide an alternative method of computing the polygon's area
- Improves triangulation tests by adding parametrized test assert on number of triangles and the computed double area of the triangulation