### PR TITLE
Add triangulation visualization

### DIFF
--- a/visualizer/src/app.rs
+++ b/visualizer/src/app.rs
@@ -5,9 +5,9 @@ pub const RESULT_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/results");
 
 #[derive(Default)]
 pub struct TemplateApp {
-    demo: crate::polygon_visualizer::PolygonVisualizer,
+    visualizer: crate::polygon_visualizer::PolygonVisualizer,
     filenames: Vec<String>,
-    selected: String,
+    selected_polygon: String,
 }
 
 impl TemplateApp {
@@ -17,42 +17,47 @@ impl TemplateApp {
             .files()
             .map(|f| String::from(f.path().file_stem().unwrap().to_str().unwrap()))
             .collect();
-        let selected = filenames[0].clone();
+        let selected_polygon = filenames[0].clone();
         
-        Self { demo: crate::polygon_visualizer::PolygonVisualizer::default(), filenames, selected}
+        Self { 
+            visualizer: crate::polygon_visualizer::PolygonVisualizer::default(), 
+            filenames, 
+            selected_polygon,
+        }
     }
 }
 
 impl eframe::App for TemplateApp {
     /// Called each time the UI needs repainting, which may be many times per second.
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::SidePanel::left("test_result_browser")
-        .resizable(true)
-        .default_width(160.0)
-        .min_width(160.0)
-        .show(ctx, |ui| {
-            ui.vertical_centered(|ui| {
-                ui.heading("Test Results");
-            });
-            ui.separator();
-
-            for name in self.filenames.iter() {
-                ui.selectable_value(
-                    &mut self.selected, 
-                    name.to_string(), 
-                    name
-                );
-            }
-        });
-
-        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+        
+        egui::TopBottomPanel::bottom("theme_panel").show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
                 egui::widgets::global_theme_preference_buttons(ui);
             });
         });
 
+        egui::SidePanel::left("polygon_browser")
+            .resizable(true)
+            .default_width(100.0)
+            .min_width(100.0)
+            .show(ctx, |ui| {
+                ui.vertical_centered(|ui| {
+                    ui.heading("Polygons");
+                });
+                ui.separator();
+
+                for name in self.filenames.iter() {
+                    ui.selectable_value(
+                        &mut self.selected_polygon, 
+                        name.to_string(), 
+                        name
+                    );
+                }
+            });
+
         egui::CentralPanel::default().show(ctx, |ui| {
-            self.demo.ui(ui, &self.selected);
+            self.visualizer.ui(ui, &self.selected_polygon);
         });
     }
 }

--- a/visualizer/src/polygon_visualizer.rs
+++ b/visualizer/src/polygon_visualizer.rs
@@ -61,7 +61,6 @@ impl Default for PolygonVisualizer {
     }
 }
 
-
 impl PolygonVisualizer {
     pub fn ui(&mut self, ui: &mut egui::Ui, name: &String) -> Response {
         
@@ -78,47 +77,61 @@ impl PolygonVisualizer {
             );
         });
         ui.separator();
-
-
-        let mut plot = Plot::new("polygon_visualizer")
-            .show_axes(true)
-            .show_grid(true);
-        
-        plot = plot.view_aspect(1.0);
-        plot = plot.data_aspect(1.0);
-        plot = plot.coordinates_formatter(
-            Corner::LeftBottom, 
-            CoordinatesFormatter::default()
-        );
         
         match self.selected_visualization {
             Visualization::Polygon => {
-                let points = self.points.get(name).unwrap();
-                let line = Line::new(points.clone())
-                    .width(self.line_width);
-                let points = Points::new(points.clone())
-                    .radius(self.point_radius);
-
-                plot.show(ui, |plot_ui| {
-                    plot_ui.line(line);
-                    plot_ui.points(points);
-                }).response
+                self.draw_polygon(ui, name)
             }
             Visualization::Triangulation => {
-
-                // TODO need to update for triangulation 
-
-                let points = self.points.get(name).unwrap();
-                let line = Line::new(points.clone())
-                    .width(self.line_width);
-                let points = Points::new(points.clone())
-                    .radius(self.point_radius);
-
-                plot.show(ui, |plot_ui| {
-                    plot_ui.line(line);
-                    plot_ui.points(points);
-                }).response
+                self.draw_triangulation(ui, name)
             }
         }
+    }
+
+    fn draw_polygon(&self, ui: &mut egui::Ui, name: &String) -> Response {
+        let points = self.points.get(name).unwrap();
+        let line = self.create_line(name);
+        let points = Points::new(points.clone())
+            .radius(self.point_radius);
+        let plot = self.create_plot();
+        
+        plot.show(ui, |plot_ui| {
+            plot_ui.line(line);
+            plot_ui.points(points);
+        }).response
+    }
+
+    fn draw_triangulation(&self, ui: &mut egui::Ui, name: &String) -> Response {
+        // TODO need to update for triangulation 
+        let plot = self.create_plot();
+
+        let points = self.points.get(name).unwrap();
+        let line = Line::new(points.clone())
+            .width(self.line_width);
+        let points = Points::new(points.clone())
+            .radius(self.point_radius);
+
+        plot.show(ui, |plot_ui| {
+            plot_ui.line(line);
+            plot_ui.points(points);
+        }).response
+    }
+
+    fn create_plot(&self) -> Plot<'_> {
+        Plot::new("polygon_visualizer")
+            .show_axes(true)
+            .show_grid(true)
+            .view_aspect(1.0)
+            .data_aspect(1.0)
+            .coordinates_formatter(
+                Corner::LeftBottom, 
+                CoordinatesFormatter::default()
+            )
+    }
+
+    fn create_line(&self, name: &String) -> Line {
+        let points = self.points.get(name).unwrap();
+        Line::new(points.clone())
+            .width(self.line_width)
     }
 }

--- a/visualizer/src/polygon_visualizer.rs
+++ b/visualizer/src/polygon_visualizer.rs
@@ -1,7 +1,7 @@
 use egui::Response;
 use egui_plot::{
     CoordinatesFormatter, Corner, Line, 
-    Plot, PlotPoints, Points, Polygon as PlotPolygon
+    Plot, Points, Polygon as PlotPolygon
 };
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -23,8 +23,6 @@ enum Visualization {
 impl fmt::Display for Visualization {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
-        // or, alternatively:
-        // fmt::Debug::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
Adds basic support for visualizing polygon triangulations.

- Adds lifetime and vertex map reference to `Triangulation`
- Adds `to_point` conversion function to `Triangulation`
- Adds support for multiple visualization types to the app
- Adds visualization of triangulations
- Adds some helper functions to make creating visualizations easier