### PR TITLE
Add basic validation of polygons on creation

### DIFF
--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -102,13 +102,24 @@ impl Polygon {
         // auto-recovery could be possible, but for now just going
         // to do asserts so it panics
 
+        self.validate_num_vertices();
+        self.validate_cycle();
+        self.validate_edge_intersections();
+        
+        // TODO add unit tests for validation failures
+        
+    }
+
+    fn validate_num_vertices(&self) {
         let num_vertices = self.num_vertices();
         assert!(
             num_vertices >= 3,
             "Polygon must have at least 3 vertices, \
             this one has {num_vertices}"
         );
-    
+    }
+
+    fn validate_cycle(&self) {
         // Walk the chain and terminate once a loop closure is
         // encountered, then validate every vertex was visited
         // once. Note the loop must terminate since there are
@@ -136,7 +147,9 @@ impl Polygon {
             "Expected vertex chain to form a cycle but these \
             vertices were not visited: {not_visited:?}"
         );
-        
+    }
+
+    fn validate_edge_intersections(&self) {
         let mut edges = Vec::new();
         let anchor_id = self.vertex_map.anchor().id;
         let mut current = self.get_vertex(&anchor_id);
@@ -152,8 +165,11 @@ impl Polygon {
         
         for i in 0..(edges.len() - 1) {
             let e1 = &edges[i];
+            // Adjacent edges should share a common vertex
+            assert!(e1.incident_to(&edges[i+1].p1));
             for j in (i+2)..(edges.len() - 1) {
                 let e2 = &edges[j];
+                // Non-adjacent edges should have no intersection
                 assert!(!e1.intersects(e2));
                 assert!(!e1.incident_to(e2.p1));
                 assert!(!e1.incident_to(e2.p2));
@@ -162,11 +178,6 @@ impl Polygon {
                 assert!(!e2.incident_to(e1.p2));
             }
         }
-
-
-
-        // TODO add unit tests for validation failures
-        
     }
     
     pub fn num_edges(&self) -> usize {

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -429,6 +429,27 @@ mod tests {
     fn all_polygons(#[case] case: PolygonTestCase) {}
 
 
+    #[test]
+    #[should_panic]
+    fn test_invalid_polygon_not_enough_vertices() {
+        let p1 = Point::new(1, 2);
+        let p2 = Point::new(3, 4);
+        let points = vec![p1, p2];
+        let polygon = Polygon::new(points);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_polygon_not_simple() {
+        let p1 = Point::new(0, 0);
+        let p2 = Point::new(2, 0);
+        let p3 = Point::new(2, 2);
+        let p4 = Point::new(0, 2);
+        let p5 = Point::new(4, 1); // This one should break it
+        let points = vec![p1, p2, p3, p4, p5];
+        let polygon = Polygon::new(points);
+    }
+
     #[apply(all_polygons)]
     fn test_json(case: PolygonTestCase) {
         let filename = NamedTempFile::new()

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -276,9 +276,8 @@ impl Polygon {
         for i in 0..(edges.len() - 1) {
             let e1 = &edges[i];
             // Adjacent edges should share a common vertex
-            assert!(e1.incident_to(&edges[i+1].p1));
-            for j in (i+2)..(edges.len() - 1) {
-                let e2 = &edges[j];
+            assert!(e1.incident_to(edges[i+1].p1));
+            for e2 in edges.iter().take(edges.len() -1).skip(i+2) {
                 // Non-adjacent edges should have no intersection
                 assert!(!e1.intersects(e2));
                 assert!(!e1.incident_to(e2.p1));

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -428,7 +428,7 @@ mod tests {
         let p1 = Point::new(1, 2);
         let p2 = Point::new(3, 4);
         let points = vec![p1, p2];
-        let polygon = Polygon::new(points);
+        let _polygon = Polygon::new(points);
     }
 
     #[test]
@@ -440,7 +440,7 @@ mod tests {
         let p4 = Point::new(0, 2);
         let p5 = Point::new(4, 1); // This one should break it
         let points = vec![p1, p2, p3, p4, p5];
-        let polygon = Polygon::new(points);
+        let _polygon = Polygon::new(points);
     }
 
     #[apply(all_polygons)]

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -88,21 +88,19 @@ impl Polygon {
     pub fn to_json<P: AsRef<Path>>(&self, path: P) {
         // TODO return result
 
-        // Getting a vec of vertices ordered by vertex ID so that it
-        // matches the order of input points as closely as possible.
-        let mut vertices = self.vertex_map
-            .values()
-            .collect::<Vec<&Vertex>>();
-        vertices.sort_by(|a, b| a.id.cmp(&b.id));
-        
-        let points = vertices
-            .iter()
-            .map(|v| v.coords.clone())
-            .collect::<Vec<Point>>();
+        let points = self.vertex_map.sorted_points();
         let points_str = serde_json::to_string(&points).unwrap();
         // TODO don't expect below or unwrap above, want to return result
         // where it can possibly error on serialization or file write
         fs::write(path, points_str).expect("File should have saved but failed");
+    }
+
+    pub fn validate(&self) -> bool {
+        let vertices = self.vertex_map.sorted_vertices();
+        // TODO add checks here. Should this return bool, 
+        // or have an error type, or do asserts?
+
+        true
     }
     
     pub fn num_edges(&self) -> usize {

--- a/computational_geometry/src/vertex.rs
+++ b/computational_geometry/src/vertex.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{
     line_segment::LineSegment,
     point::Point,
@@ -16,6 +18,12 @@ impl From<u32> for VertexId {
 impl From<usize> for VertexId {
     fn from(raw: usize) -> Self {
         Self(raw.try_into().unwrap())
+    }
+}
+
+impl fmt::Display for VertexId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/computational_geometry/src/vertex_map.rs
+++ b/computational_geometry/src/vertex_map.rs
@@ -61,6 +61,20 @@ impl VertexMap {
         self.map.values()
     }
 
+    pub fn sorted_vertices(&self) -> Vec<&Vertex> {
+        let mut vertices = self.values()
+            .collect::<Vec<&Vertex>>();
+        vertices.sort_by(|a, b| a.id.cmp(&b.id));
+        vertices
+    }
+
+    pub fn sorted_points(&self) -> Vec<Point> {
+        self.sorted_vertices()
+            .iter()
+            .map(|v| v.coords.clone())
+            .collect::<Vec<Point>>()
+    }
+
     pub fn anchor(&self) -> &Vertex {
         // TODO I'm not yet convinced this is something I want, ultimately
         // need something to initiate algorithms in the vertex chain.


### PR DESCRIPTION
This change adds basic validation of polygons on creation, validating:
1. Number of vertices (at least 3)
2. Valid cycle visiting every vertex once in chain
3. Edge intersection validation, that adjacent edges share a vertex and non-adjacent edges do not intersect