### PR TITLE
Disable feathering to prevent artifacts in visualizer

### DIFF
--- a/visualizer/src/app.rs
+++ b/visualizer/src/app.rs
@@ -56,6 +56,15 @@ impl eframe::App for TemplateApp {
                 }
             });
 
+        // This was needed to workaround some artifacts in the plot for
+        // highly obtuse triangles in triangulations. It's possible it
+        // causes other problems down the road, so can try setting to
+        // true if other things look strange.
+        // https://github.com/adamconkey/computational_geometry/issues/17
+        ctx.tessellation_options_mut(|to| {
+            to.feathering = false;
+        });
+
         egui::CentralPanel::default().show(ctx, |ui| {
             self.visualizer.ui(ui, &self.selected_polygon);
         });


### PR DESCRIPTION
Fixes artifacts in the visualizations of some of the IPA polygons by disabling feathering in the tesselation which seemed to be the root cause. Previously you would see long lines shooting out from some of the triangles in the triangulations, particularly very thin obtuse ones, those artifacts are gone with this change.