### PR TITLE
Switch to using f64 types instead of i32 for coordinates and area

### DIFF
--- a/computational_geometry/resources/test/custom/polygon_1.meta.json
+++ b/computational_geometry/resources/test/custom/polygon_1.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 88,
+    "area": 44,
     "num_edges": 6,
     "num_triangles": 4,
     "num_vertices": 6

--- a/computational_geometry/resources/test/custom/polygon_2.meta.json
+++ b/computational_geometry/resources/test/custom/polygon_2.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 466,
+    "area": 233,
     "num_edges": 18,
     "num_triangles": 16,
     "num_vertices": 18

--- a/computational_geometry/resources/test/custom/right_triangle.meta.json
+++ b/computational_geometry/resources/test/custom/right_triangle.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 12,
+    "area": 6,
     "num_edges": 3,
     "num_triangles": 1,
     "num_vertices": 3

--- a/computational_geometry/resources/test/custom/square_4x4.meta.json
+++ b/computational_geometry/resources/test/custom/square_4x4.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 32,
+    "area": 16,
     "num_edges": 4,
     "num_triangles": 2,
     "num_vertices": 4

--- a/computational_geometry/resources/test/interesting_polygon_archive/eberly_10.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/eberly_10.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 328143,
+    "area": 164071.5,
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/resources/test/interesting_polygon_archive/eberly_14.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/eberly_14.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 719396,
+    "area": 359698,
     "num_edges": 6,
     "num_triangles": 4,
     "num_vertices": 6

--- a/computational_geometry/resources/test/interesting_polygon_archive/elgindy_1.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/elgindy_1.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 224940,
+    "area": 112470,
     "num_edges": 17,
     "num_triangles": 15,
     "num_vertices": 17

--- a/computational_geometry/resources/test/interesting_polygon_archive/gray_embroidery.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/gray_embroidery.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 590946,
+    "area": 295473,
     "num_edges": 32,
     "num_triangles": 30,
     "num_vertices": 32

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_1.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_1.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 560469,
+    "area": 280234.5,
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_12.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_12.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 174542,
+    "area": 87271,
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_3.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_3.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 356249,
+    "area": 178124.5,
     "num_edges": 25,
     "num_triangles": 23,
     "num_vertices": 25

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_7a.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_7a.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 405973,
+    "area": 202986.5,
     "num_edges": 64,
     "num_triangles": 62,
     "num_vertices": 64

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_7b.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_7b.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 299184,
+    "area": 149592,
     "num_edges": 63,
     "num_triangles": 61,
     "num_vertices": 63

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_7c.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_7c.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 116709,
+    "area": 58354.5,
     "num_edges": 64,
     "num_triangles": 62,
     "num_vertices": 64

--- a/computational_geometry/resources/test/interesting_polygon_archive/held_7d.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/held_7d.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 211858,
+    "area": 105929,
     "num_edges": 61,
     "num_triangles": 59,
     "num_vertices": 61

--- a/computational_geometry/resources/test/interesting_polygon_archive/mapbox_building.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mapbox_building.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 5214,
+    "area": 2607,
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/resources/test/interesting_polygon_archive/mapbox_dude.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mapbox_dude.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 30715,
+    "area": 15357.5,
     "num_edges": 94,
     "num_triangles": 92,
     "num_vertices": 94

--- a/computational_geometry/resources/test/interesting_polygon_archive/matisse_alga.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/matisse_alga.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 454336,
+    "area": 227168,
     "num_edges": 166,
     "num_triangles": 164,
     "num_vertices": 166

--- a/computational_geometry/resources/test/interesting_polygon_archive/matisse_blue.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/matisse_blue.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 1267232,
+    "area": 633616,
     "num_edges": 4,
     "num_triangles": 2,
     "num_vertices": 4

--- a/computational_geometry/resources/test/interesting_polygon_archive/matisse_icarus.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/matisse_icarus.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 229654,
+    "area": 114827,
     "num_edges": 83,
     "num_triangles": 81,
     "num_vertices": 83

--- a/computational_geometry/resources/test/interesting_polygon_archive/matisse_nuit.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/matisse_nuit.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 147599,
+    "area": 73799.5,
     "num_edges": 124,
     "num_triangles": 122,
     "num_vertices": 124

--- a/computational_geometry/resources/test/interesting_polygon_archive/mei_2.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mei_2.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 459901,
+    "area": 229950.5,
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/resources/test/interesting_polygon_archive/mei_3.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mei_3.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 360027,
+    "area": 180013.5,
     "num_edges": 42,
     "num_triangles": 40,
     "num_vertices": 42

--- a/computational_geometry/resources/test/interesting_polygon_archive/mei_4.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mei_4.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 587878,
+    "area": 293939,
     "num_edges": 69,
     "num_triangles": 67,
     "num_vertices": 69

--- a/computational_geometry/resources/test/interesting_polygon_archive/mei_5.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mei_5.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 541788,
+    "area": 270894,
     "num_edges": 279,
     "num_triangles": 277,
     "num_vertices": 279

--- a/computational_geometry/resources/test/interesting_polygon_archive/mei_6.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/mei_6.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 635280,
+    "area": 317640,
     "num_edges": 173,
     "num_triangles": 171,
     "num_vertices": 173

--- a/computational_geometry/resources/test/interesting_polygon_archive/meisters_3.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/meisters_3.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 174180,
+    "area": 87090,
     "num_edges": 30,
     "num_triangles": 28,
     "num_vertices": 30

--- a/computational_geometry/resources/test/interesting_polygon_archive/misc_discobolus.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/misc_discobolus.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 285822,
+    "area": 142911,
     "num_edges": 116,
     "num_triangles": 114,
     "num_vertices": 116

--- a/computational_geometry/resources/test/interesting_polygon_archive/misc_fu.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/misc_fu.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 640663,
+    "area": 320331.5,
     "num_edges": 134,
     "num_triangles": 132,
     "num_vertices": 134

--- a/computational_geometry/resources/test/interesting_polygon_archive/seidel_3.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/seidel_3.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 454260,
+    "area": 227130,
     "num_edges": 20,
     "num_triangles": 18,
     "num_vertices": 20

--- a/computational_geometry/resources/test/interesting_polygon_archive/skimage_horse.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/skimage_horse.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 360288,
+    "area": 180144,
     "num_edges": 119,
     "num_triangles": 117,
     "num_vertices": 119

--- a/computational_geometry/resources/test/interesting_polygon_archive/toussaint_1a.meta.json
+++ b/computational_geometry/resources/test/interesting_polygon_archive/toussaint_1a.meta.json
@@ -1,5 +1,5 @@
 {
-    "double_area": 476220,
+    "area": 238110,
     "num_edges": 125,
     "num_triangles": 123,
     "num_vertices": 125

--- a/computational_geometry/src/line_segment.rs
+++ b/computational_geometry/src/line_segment.rs
@@ -53,9 +53,8 @@ impl<'a> LineSegment<'a> {
             return false;
         }
         
-        let ab_splits_cd = abc.area_sign() * abd.area_sign() < 0.0;
-        let cd_splits_ab = cda.area_sign() * cdb.area_sign() < 0.0;
-                
+        let ab_splits_cd = c.left(self) ^ d.left(self);
+        let cd_splits_ab = a.left(cd) ^ b.left(cd);
         ab_splits_cd && cd_splits_ab
     }
         

--- a/computational_geometry/src/line_segment.rs
+++ b/computational_geometry/src/line_segment.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct LineSegment<'a> {
     pub p1: &'a Point,
     pub p2: &'a Point,
@@ -53,8 +53,8 @@ impl<'a> LineSegment<'a> {
             return false;
         }
         
-        let ab_splits_cd = abc.area_sign() * abd.area_sign() < 0;
-        let cd_splits_ab = cda.area_sign() * cdb.area_sign() < 0;
+        let ab_splits_cd = abc.area_sign() * abd.area_sign() < 0.0;
+        let cd_splits_ab = cda.area_sign() * cdb.area_sign() < 0.0;
                 
         ab_splits_cd && cd_splits_ab
     }
@@ -88,10 +88,10 @@ mod tests {
 
     #[test]
     fn test_proper_intersect() {
-        let a = Point::new(6, 4);
-        let b = Point::new(0, 4);
-        let c = Point::new(1, 0);
-        let d = Point::new(4, 6);
+        let a = Point::new(6.0, 4.0);
+        let b = Point::new(0.0, 4.0);
+        let c = Point::new(1.0, 0.0);
+        let d = Point::new(4.0, 6.0);
 
         let ab = LineSegment::new(&a, &b);
         let cd = LineSegment::new(&c, &d);
@@ -106,10 +106,10 @@ mod tests {
 
     #[test]
     fn test_improper_intersect() {
-        let a = Point::new(6, 6);
-        let b = Point::new(0, 6);
-        let c = Point::new(1, 0);
-        let d = Point::new(4, 6);
+        let a = Point::new(6.0, 6.0);
+        let b = Point::new(0.0, 6.0);
+        let c = Point::new(1.0, 0.0);
+        let d = Point::new(4.0, 6.0);
 
         let ab = LineSegment::new(&a, &b);
         let cd = LineSegment::new(&c, &d);
@@ -124,10 +124,10 @@ mod tests {
 
     #[test]
     fn test_no_intersect() {
-        let a = Point::new(6, 4);
-        let b = Point::new(4, 4);
-        let c = Point::new(1, 0);
-        let d = Point::new(4, 6);
+        let a = Point::new(6.0, 4.0);
+        let b = Point::new(4.0, 4.0);
+        let c = Point::new(1.0, 0.0);
+        let d = Point::new(4.0, 6.0);
 
         let ab = LineSegment::new(&a, &b);
         let cd = LineSegment::new(&c, &d);
@@ -142,8 +142,8 @@ mod tests {
 
     #[test]
     fn test_intersect_with_self() {
-        let a = Point::new(6, 4);
-        let b = Point::new(4, 4);
+        let a = Point::new(6.0, 4.0);
+        let b = Point::new(4.0, 4.0);
         let ab = LineSegment::new(&a, &b);
 
         assert!(!ab.proper_intersects(&ab));
@@ -153,8 +153,8 @@ mod tests {
 
     #[test]
     fn test_reverse() {
-        let a = Point::new(0, 0);
-        let b = Point::new(1, 2);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(1.0, 2.0);
         let ab = LineSegment::new(&a, &b);
         let ba = ab.reverse();
         assert_eq!(ab.p1, &a);

--- a/computational_geometry/src/point.rs
+++ b/computational_geometry/src/point.rs
@@ -32,11 +32,11 @@ impl Point {
     }
 
     pub fn left(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).area_sign() > 0.0
+        Triangle::new(ab.p1, ab.p2, self).double_area() > 0.0
     }
 
     pub fn left_on(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).area_sign() >= 0.0
+        Triangle::new(ab.p1, ab.p2, self).double_area() >= 0.0
     }
 }
 

--- a/computational_geometry/src/point.rs
+++ b/computational_geometry/src/point.rs
@@ -32,11 +32,11 @@ impl Point {
     }
 
     pub fn left(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).double_area() > 0.0
+        Triangle::new(ab.p1, ab.p2, self).area() > 0.0
     }
 
     pub fn left_on(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).double_area() >= 0.0
+        Triangle::new(ab.p1, ab.p2, self).area() >= 0.0
     }
 }
 

--- a/computational_geometry/src/point.rs
+++ b/computational_geometry/src/point.rs
@@ -6,15 +6,15 @@ use crate::{
 };
 
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Point {
-    pub x: i32,
-    pub y: i32,
+    pub x: f64,
+    pub y: f64,
 }
 
 
 impl Point {
-    pub fn new(x: i32, y: i32) -> Self {
+    pub fn new(x: f64, y: f64) -> Self {
         Point { x, y }
     }
 
@@ -32,11 +32,11 @@ impl Point {
     }
 
     pub fn left(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).area_sign() > 0
+        Triangle::new(ab.p1, ab.p2, self).area_sign() > 0.0
     }
 
     pub fn left_on(&self, ab: &LineSegment) -> bool {
-        Triangle::new(ab.p1, ab.p2, self).area_sign() >= 0
+        Triangle::new(ab.p1, ab.p2, self).area_sign() >= 0.0
     }
 }
 
@@ -47,7 +47,7 @@ mod tests {
  
     #[test]
     fn test_serialize_point() {
-        let p = Point::new(1, 2);
+        let p = Point::new(1.0, 2.0);
         let serialized = serde_json::to_string(&p).unwrap();
         let deserialized: Point = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, p);
@@ -55,8 +55,8 @@ mod tests {
 
     #[test]
     fn test_serialize_points_vec() {
-        let p1 = Point::new(1, 2);
-        let p2 = Point::new(3, 4);
+        let p1 = Point::new(1.0, 2.0);
+        let p2 = Point::new(3.0, 4.0);
         let points = vec![p1, p2];
         let serialized = serde_json::to_string(&points).unwrap();
         let deserialized: Vec<Point> = serde_json::from_str(&serialized).unwrap();
@@ -65,9 +65,9 @@ mod tests {
 
     #[test]
     fn test_between() {
-        let p0 = Point::new(0, 0);
-        let p1 = Point::new(1, 1);
-        let p2 = Point::new(2, 2);
+        let p0 = Point::new(0.0, 0.0);
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 2.0);
 
         assert!( p1.between(&p0, &p2));
         assert!( p1.between(&p2, &p1));
@@ -79,9 +79,9 @@ mod tests {
 
     #[test]
     fn test_between_vertical() {
-        let p0 = Point::new(0, 0);
-        let p1 = Point::new(0, 1);
-        let p2 = Point::new(0, 2);
+        let p0 = Point::new(0.0, 0.0);
+        let p1 = Point::new(0.0, 1.0);
+        let p2 = Point::new(0.0, 2.0);
 
         assert!( p1.between(&p0, &p2));
         assert!( p1.between(&p2, &p1));

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -53,7 +53,7 @@ impl<'a> Triangulation<'a> {
         self.triangles.is_empty()
     }
 
-    pub fn to_points(&self) -> HashSet<(Point, Point, Point)> {
+    pub fn to_points(&self) -> Vec<(Point, Point, Point)> {
         self.triangles.iter()
             .map(|ids| 
                 (
@@ -105,13 +105,13 @@ impl Polygon {
         self.vertex_map.len()
     }
 
-    pub fn double_area(&self) -> i32 {
+    pub fn double_area(&self) -> f64 {
         // Computes double area of the polygon.
         //
         // NOTE: This is computing double area so that I can stick to
         // i32 return types in this preliminary implementation and
         // not worry about floating point issues.
-        let mut area = 0;
+        let mut area = 0.0;
         let anchor = self.vertex_map.anchor();
         for v1 in self.vertex_map.values() {
             let v2 = self.get_vertex(&v1.next); 
@@ -120,13 +120,13 @@ impl Polygon {
         area
     }
 
-    pub fn double_area_from_triangulation(&self, triangulation: &Triangulation) -> i32 {
+    pub fn double_area_from_triangulation(&self, triangulation: &Triangulation) -> f64 {
         // Computes double area from a triangulation as the sum of
         // the double area of the individual triangles that 
         // constitute the triangulation.
         // 
         // This value should always be exactly equal to `self.double_area()`.
-        let mut area = 0;
+        let mut area = 0.0;
         for (p1, p2, p3) in triangulation.to_points().iter() {
             area += Triangle::new(p1, p2, p3).double_area();
         }
@@ -302,7 +302,7 @@ mod tests {
 
     #[derive(Deserialize)]
     struct PolygonMetadata {
-        double_area: i32,
+        double_area: f64,
         num_edges: usize,
         num_triangles: usize,
         num_vertices: usize,
@@ -424,8 +424,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_invalid_polygon_not_enough_vertices() {
-        let p1 = Point::new(1, 2);
-        let p2 = Point::new(3, 4);
+        let p1 = Point::new(1.0, 2.0);
+        let p2 = Point::new(3.0, 4.0);
         let points = vec![p1, p2];
         let polygon = Polygon::new(points);
         assert_eq!(2, polygon.num_vertices());
@@ -434,11 +434,11 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_invalid_polygon_not_simple() {
-        let p1 = Point::new(0, 0);
-        let p2 = Point::new(2, 0);
-        let p3 = Point::new(2, 2);
-        let p4 = Point::new(0, 2);
-        let p5 = Point::new(4, 1); // This one should break it
+        let p1 = Point::new(0.0, 0.0);
+        let p2 = Point::new(2.0, 0.0);
+        let p3 = Point::new(2.0, 2.0);
+        let p4 = Point::new(0.0, 2.0);
+        let p5 = Point::new(4.0, 1.0); // This one should break it
         let points = vec![p1, p2, p3, p4, p5];
         let polygon = Polygon::new(points);
         assert_eq!(3, polygon.num_vertices())

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -105,30 +105,23 @@ impl Polygon {
         self.vertex_map.len()
     }
 
-    pub fn double_area(&self) -> f64 {
-        // Computes double area of the polygon.
-        //
-        // NOTE: This is computing double area so that I can stick to
-        // i32 return types in this preliminary implementation and
-        // not worry about floating point issues.
+    pub fn area(&self) -> f64 {
         let mut area = 0.0;
         let anchor = self.vertex_map.anchor();
         for v1 in self.vertex_map.values() {
             let v2 = self.get_vertex(&v1.next); 
-            area += Triangle::from_vertices(anchor, v1, v2).double_area();
+            area += Triangle::from_vertices(anchor, v1, v2).area();
         }
         area
     }
 
-    pub fn double_area_from_triangulation(&self, triangulation: &Triangulation) -> f64 {
-        // Computes double area from a triangulation as the sum of
-        // the double area of the individual triangles that 
-        // constitute the triangulation.
-        // 
-        // This value should always be exactly equal to `self.double_area()`.
+    pub fn area_from_triangulation(&self, triangulation: &Triangulation) -> f64 {
+        // Computes area from a triangulation as the sum of the area of 
+        // the individual triangles that constitute the triangulation.
+        // This value should always be exactly equal to `self.area()`.
         let mut area = 0.0;
         for (p1, p2, p3) in triangulation.to_points().iter() {
-            area += Triangle::new(p1, p2, p3).double_area();
+            area += Triangle::new(p1, p2, p3).area();
         }
         area
     }
@@ -302,7 +295,7 @@ mod tests {
 
     #[derive(Deserialize)]
     struct PolygonMetadata {
-        double_area: f64,
+        area: f64,
         num_edges: usize,
         num_triangles: usize,
         num_vertices: usize,
@@ -456,8 +449,8 @@ mod tests {
 
     #[apply(all_polygons)]
     fn test_area(case: PolygonTestCase) {
-        let double_area = case.polygon.double_area();
-        assert_eq!(double_area, case.metadata.double_area);
+        let area = case.polygon.area();
+        assert_eq!(area, case.metadata.area);
     }
 
     #[apply(all_polygons)]
@@ -482,8 +475,8 @@ mod tests {
         // if holes are present and then this assert would be conditional
         assert_eq!(case.metadata.num_triangles, case.metadata.num_edges - 2);
 
-        let triangulation_double_area = case.polygon.double_area_from_triangulation(&triangulation);
-        assert_eq!(triangulation_double_area, case.metadata.double_area);
+        let triangulation_area = case.polygon.area_from_triangulation(&triangulation);
+        assert_eq!(triangulation_area, case.metadata.area);
     }
 
     #[apply(all_polygons)]

--- a/computational_geometry/src/triangle.rs
+++ b/computational_geometry/src/triangle.rs
@@ -30,13 +30,8 @@ impl<'a> Triangle<'a> {
         })
     }
 
-    // TODO this doesn't work with floats need to fix
-    pub fn area_sign(&self) -> f64 {
-        self.double_area().signum()
-    }
-
     pub fn has_collinear_points(&self) -> bool {
-        self.area_sign() == 0.0
+        self.double_area() == 0.0
     }
 }
 
@@ -74,7 +69,7 @@ mod tests {
     // TODO want some better unit tests for the triangle area
 
     #[test]
-    fn test_area_sign_clockwise() {
+    fn test_area_clockwise() {
         let a = Point::new(0.0, 0.0);
         let b = Point::new(4.0, 3.0);
         let c = Point::new(1.0, 3.0);
@@ -85,12 +80,12 @@ mod tests {
             Triangle::new(&b, &a, &c),
         ];
         for triangle in cw {
-            assert_eq!(triangle.area_sign(), -1.0);
+            assert!(triangle.double_area() < 0.0);
         }
     }
 
     #[test]
-    fn test_area_sign_counter_clockwise() {
+    fn test_area_counter_clockwise() {
         let a = Point::new(0.0, 0.0);
         let b = Point::new(4.0, 3.0);
         let c = Point::new(1.0, 3.0);
@@ -101,12 +96,12 @@ mod tests {
             Triangle::new(&c, &a, &b),
         ];
         for triangle in ccw {
-            assert_eq!(triangle.area_sign(), 1.0);
+            assert!(triangle.double_area() > 0.0);
         }
     }
 
     #[test]
-    fn test_area_sign_collinear() {
+    fn test_area_collinear() {
         let a = Point::new(0.0, 0.0);
         let b = Point::new(4.0, 3.0);
         let c = Point::new(1.0, 3.0);

--- a/computational_geometry/src/triangle.rs
+++ b/computational_geometry/src/triangle.rs
@@ -10,28 +10,28 @@ pub struct Triangle<'a> {
     pub p1: &'a Point,
     pub p2: &'a Point,
     pub p3: &'a Point,
-    double_area: OnceCell<f64>,
+    area: OnceCell<f64>,
 }
 
 impl<'a> Triangle<'a> {
     pub fn new(p1: &'a Point, p2: &'a Point, p3: &'a Point) -> Triangle<'a> {
-        Triangle { p1, p2, p3, double_area: OnceCell::new() }
+        Triangle { p1, p2, p3, area: OnceCell::new() }
     }
 
     pub fn from_vertices(v1: &'a Vertex, v2: &'a Vertex, v3: &'a Vertex) -> Triangle<'a> {
         Triangle::new(&v1.coords, &v2.coords, &v3.coords)
     }
 
-    pub fn double_area(&self) -> f64 {
-        *self.double_area.get_or_init(|| {
+    pub fn area(&self) -> f64 {
+        *self.area.get_or_init(|| {
             let t1 = (self.p2.x - self.p1.x) * (self.p3.y - self.p1.y);
             let t2 = (self.p3.x - self.p1.x) * (self.p2.y - self.p1.y);
-            t1 - t2
+            0.5 * (t1 - t2)
         })
     }
 
     pub fn has_collinear_points(&self) -> bool {
-        self.double_area() == 0.0
+        self.area() == 0.0
     }
 }
 
@@ -62,8 +62,8 @@ mod tests {
         let b = Point::new(3.0, 0.0);
         let c = Point::new(0.0, 4.0);
         let triangle = Triangle::new(&a, &b, &c);
-        let double_area = triangle.double_area();
-        assert_eq!(double_area, 12.0);
+        let area = triangle.area();
+        assert_eq!(area, 6.0);
     }
 
     // TODO want some better unit tests for the triangle area
@@ -80,7 +80,7 @@ mod tests {
             Triangle::new(&b, &a, &c),
         ];
         for triangle in cw {
-            assert!(triangle.double_area() < 0.0);
+            assert!(triangle.area() < 0.0);
         }
     }
 
@@ -96,7 +96,7 @@ mod tests {
             Triangle::new(&c, &a, &b),
         ];
         for triangle in ccw {
-            assert!(triangle.double_area() > 0.0);
+            assert!(triangle.area() > 0.0);
         }
     }
 

--- a/computational_geometry/src/triangle.rs
+++ b/computational_geometry/src/triangle.rs
@@ -10,7 +10,7 @@ pub struct Triangle<'a> {
     pub p1: &'a Point,
     pub p2: &'a Point,
     pub p3: &'a Point,
-    double_area: OnceCell<i32>,
+    double_area: OnceCell<f64>,
 }
 
 impl<'a> Triangle<'a> {
@@ -22,7 +22,7 @@ impl<'a> Triangle<'a> {
         Triangle::new(&v1.coords, &v2.coords, &v3.coords)
     }
 
-    pub fn double_area(&self) -> i32 {
+    pub fn double_area(&self) -> f64 {
         *self.double_area.get_or_init(|| {
             let t1 = (self.p2.x - self.p1.x) * (self.p3.y - self.p1.y);
             let t2 = (self.p3.x - self.p1.x) * (self.p2.y - self.p1.y);
@@ -30,12 +30,12 @@ impl<'a> Triangle<'a> {
         })
     }
 
-    pub fn area_sign(&self) -> i32 {
+    pub fn area_sign(&self) -> f64 {
         self.double_area().signum()
     }
 
     pub fn has_collinear_points(&self) -> bool {
-        self.area_sign() == 0
+        self.area_sign() == 0.0
     }
 }
 
@@ -51,32 +51,32 @@ mod tests {
         let id1 = VertexId::from(1u32);
         let id2 = VertexId::from(2u32);
         let id3 = VertexId::from(3u32);
-        let v1 = Vertex::new(Point::new(0, 0), id1, id3, id2);
-        let v2 = Vertex::new(Point::new(3, 0), id2, id1, id3);
-        let v3 = Vertex::new(Point::new(0, 4), id3, id2, id1);
+        let v1 = Vertex::new(Point::new(0.0, 0.0), id1, id3, id2);
+        let v2 = Vertex::new(Point::new(3.0, 0.0), id2, id1, id3);
+        let v3 = Vertex::new(Point::new(0.0, 4.0), id3, id2, id1);
         let triangle = Triangle::from_vertices(&v1, &v2, &v3);
-        assert_eq!(Point::new(0, 0), *triangle.p1);   
-        assert_eq!(Point::new(3, 0), *triangle.p2);   
-        assert_eq!(Point::new(0, 4), *triangle.p3);   
+        assert_eq!(Point::new(0.0, 0.0), *triangle.p1);   
+        assert_eq!(Point::new(3.0, 0.0), *triangle.p2);   
+        assert_eq!(Point::new(0.0, 4.0), *triangle.p3);   
     }
 
     #[test]
     fn test_area_right_triangle() {
-        let a = Point::new(0, 0);
-        let b = Point::new(3, 0);
-        let c = Point::new(0, 4);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(3.0, 0.0);
+        let c = Point::new(0.0, 4.0);
         let triangle = Triangle::new(&a, &b, &c);
         let double_area = triangle.double_area();
-        assert_eq!(double_area, 12);
+        assert_eq!(double_area, 12.0);
     }
 
     // TODO want some better unit tests for the triangle area
 
     #[test]
     fn test_area_sign_clockwise() {
-        let a = Point::new(0, 0);
-        let b = Point::new(4, 3);
-        let c = Point::new(1, 3);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(4.0, 3.0);
+        let c = Point::new(1.0, 3.0);
         
         let cw = vec![
             Triangle::new(&a, &c, &b),
@@ -84,15 +84,15 @@ mod tests {
             Triangle::new(&b, &a, &c),
         ];
         for triangle in cw {
-            assert_eq!(triangle.area_sign(), -1);
+            assert_eq!(triangle.area_sign(), -1.0);
         }
     }
 
     #[test]
     fn test_area_sign_counter_clockwise() {
-        let a = Point::new(0, 0);
-        let b = Point::new(4, 3);
-        let c = Point::new(1, 3);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(4.0, 3.0);
+        let c = Point::new(1.0, 3.0);
 
         let ccw = vec![
             Triangle::new(&a, &b, &c),
@@ -100,15 +100,15 @@ mod tests {
             Triangle::new(&c, &a, &b),
         ];
         for triangle in ccw {
-            assert_eq!(triangle.area_sign(), 1);
+            assert_eq!(triangle.area_sign(), 1.0);
         }
     }
 
     #[test]
     fn test_area_sign_collinear() {
-        let a = Point::new(0, 0);
-        let b = Point::new(4, 3);
-        let c = Point::new(1, 3);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(4.0, 3.0);
+        let c = Point::new(1.0, 3.0);
 
         // This is choice with replacement over a 3-tuple, so there are
         // 3 * 3 * 3 = 27 total options and this generates all of them.

--- a/computational_geometry/src/triangle.rs
+++ b/computational_geometry/src/triangle.rs
@@ -30,6 +30,7 @@ impl<'a> Triangle<'a> {
         })
     }
 
+    // TODO this doesn't work with floats need to fix
     pub fn area_sign(&self) -> f64 {
         self.double_area().signum()
     }

--- a/computational_geometry/src/vertex.rs
+++ b/computational_geometry/src/vertex.rs
@@ -28,7 +28,7 @@ impl fmt::Display for VertexId {
 }
 
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Vertex {
     pub coords: Point,
     pub id: VertexId,

--- a/visualizer/src/polygon_visualizer.rs
+++ b/visualizer/src/polygon_visualizer.rs
@@ -3,7 +3,7 @@ use egui_plot::{
     CoordinatesFormatter, Corner, Line, 
     Plot, Points, Polygon as PlotPolygon
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 
 use computational_geometry::{
@@ -30,7 +30,7 @@ impl fmt::Display for Visualization {
 //#[derive(PartialEq)]
 pub struct PolygonVisualizer {
     points: HashMap<String, Vec<[f64; 2]>>,
-    triangulations: HashMap<String, HashSet<(Point, Point, Point)>>,
+    triangulations: HashMap<String, Vec<(Point, Point, Point)>>,
     line_width: f32,
     point_radius: f32,
     selected_visualization: Visualization,

--- a/visualizer/src/polygon_visualizer.rs
+++ b/visualizer/src/polygon_visualizer.rs
@@ -49,7 +49,7 @@ impl Default for PolygonVisualizer {
 
             let mut plot_points: Vec<_> = polygon_points
                 .iter()
-                .map(|p: &Point| [f64::from(p.x), f64::from(p.y)])
+                .map(|p: &Point| [p.x, p.y])
                 .collect();
             // Pushing first to end so it closes the chain, probably
             // only want to do this for line points since it
@@ -118,12 +118,7 @@ impl PolygonVisualizer {
             .iter()
             .map(|(p1, p2, p3)|
                 PlotPolygon::new(
-                    vec![
-                        // TODO could simplify this with an impl from
-                        [f64::from(p1.x), f64::from(p1.y)],
-                        [f64::from(p2.x), f64::from(p2.y)],
-                        [f64::from(p3.x), f64::from(p3.y)],
-                    ]
+                    vec![[p1.x, p1.y], [p2.x, p2.y], [p3.x, p3.y]]
                 )
         ).collect();
 


### PR DESCRIPTION
This change switches to using `f64` types anywhere `i32` was previously used for coordinate values and area computations. It is mostly a trivial transcription, where the more substantial changes include:
- Computing area directly instead of double area (a welcome change)
- Removing determinations based on the sign of area, instead using area directly (since `signum` is not as interpretable on floats as it is for ints)
- Modifying the line segment intersection determination to use point-segment "left" determinations and bitwise operations on the bools instead of computations on area sign
- Updating all tests to use area directly instead of double area