### PR TITLE
Add naive interior point algorithm from O'Rourke

### DIFF
--- a/computational_geometry/Cargo.toml
+++ b/computational_geometry/Cargo.toml
@@ -8,12 +8,12 @@ name = "generate-rotated-ipa-polygons"
 path = "src/bin/generate_rotated_ipa_polygons.rs"
 
 [dependencies]
+itertools = "0.14.0"
 serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-itertools = "0.14.0"
 paste = "*"
 rstest = "0.24.0"
 rstest_reuse = "*"

--- a/computational_geometry/polygons/custom/polygon_1.meta.json
+++ b/computational_geometry/polygons/custom/polygon_1.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 44,
+    "interior_points": [1],
     "num_edges": 6,
     "num_triangles": 4,
     "num_vertices": 6

--- a/computational_geometry/polygons/custom/polygon_1.meta.json
+++ b/computational_geometry/polygons/custom/polygon_1.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 44,
+    "extreme_points": [0, 2, 3, 4, 5],
     "interior_points": [1],
     "num_edges": 6,
     "num_triangles": 4,

--- a/computational_geometry/polygons/custom/polygon_2.meta.json
+++ b/computational_geometry/polygons/custom/polygon_2.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 233,
+    "extreme_points": [0, 2, 3, 4, 11, 12, 16],
     "interior_points": [1, 5, 6, 7, 8, 9, 10, 13, 14, 15, 17],
     "num_edges": 18,
     "num_triangles": 16,

--- a/computational_geometry/polygons/custom/polygon_2.meta.json
+++ b/computational_geometry/polygons/custom/polygon_2.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 233,
+    "interior_points": [1, 5, 6, 7, 8, 9, 10, 13, 14, 15, 17],
     "num_edges": 18,
     "num_triangles": 16,
     "num_vertices": 18

--- a/computational_geometry/polygons/custom/right_triangle.meta.json
+++ b/computational_geometry/polygons/custom/right_triangle.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 6,
+    "interior_points": [],
     "num_edges": 3,
     "num_triangles": 1,
     "num_vertices": 3

--- a/computational_geometry/polygons/custom/right_triangle.meta.json
+++ b/computational_geometry/polygons/custom/right_triangle.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 6,
+    "extreme_points": [0, 1, 2],
     "interior_points": [],
     "num_edges": 3,
     "num_triangles": 1,

--- a/computational_geometry/polygons/custom/square_4x4.meta.json
+++ b/computational_geometry/polygons/custom/square_4x4.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 16,
+    "interior_points": [],
     "num_edges": 4,
     "num_triangles": 2,
     "num_vertices": 4

--- a/computational_geometry/polygons/custom/square_4x4.meta.json
+++ b/computational_geometry/polygons/custom/square_4x4.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 16,
+    "extreme_points": [0, 1, 2, 3],
     "interior_points": [],
     "num_edges": 4,
     "num_triangles": 2,

--- a/computational_geometry/polygons/interesting_polygon_archive/eberly_10.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/eberly_10.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 164071.5,
+    "interior_points": [],
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/polygons/interesting_polygon_archive/eberly_10.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/eberly_10.meta.json
@@ -1,6 +1,7 @@
 {
     "area": 164071.5,
-    "interior_points": [],
+    "extreme_points": [0, 10, 12, 13, 14],
+    "interior_points": [1, 2, 3, 4, 5, 6, 7, 8, 9, 11],
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/polygons/interesting_polygon_archive/eberly_14.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/eberly_14.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 359698,
+    "interior_points": [],
     "num_edges": 6,
     "num_triangles": 4,
     "num_vertices": 6

--- a/computational_geometry/polygons/interesting_polygon_archive/eberly_14.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/eberly_14.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 359698,
+    "extreme_points": [0, 1, 2, 3, 4, 5],
     "interior_points": [],
     "num_edges": 6,
     "num_triangles": 4,

--- a/computational_geometry/polygons/interesting_polygon_archive/elgindy_1.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/elgindy_1.meta.json
@@ -1,6 +1,7 @@
 {
     "area": 112470,
-    "interior_points": [],
+    "extreme_points": [0, 9, 10, 11, 12],
+    "interior_points": [1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16],
     "num_edges": 17,
     "num_triangles": 15,
     "num_vertices": 17

--- a/computational_geometry/polygons/interesting_polygon_archive/elgindy_1.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/elgindy_1.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 112470,
+    "interior_points": [],
     "num_edges": 17,
     "num_triangles": 15,
     "num_vertices": 17

--- a/computational_geometry/polygons/interesting_polygon_archive/gray_embroidery.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/gray_embroidery.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 295473,
+    "interior_points": [],
     "num_edges": 32,
     "num_triangles": 30,
     "num_vertices": 32

--- a/computational_geometry/polygons/interesting_polygon_archive/gray_embroidery.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/gray_embroidery.meta.json
@@ -1,6 +1,7 @@
 {
     "area": 295473,
-    "interior_points": [],
+    "extreme_points": [0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 24],
+    "interior_points": [2, 11, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28, 29, 30, 31],
     "num_edges": 32,
     "num_triangles": 30,
     "num_vertices": 32

--- a/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 280234.5,
+    "interior_points": [],
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
@@ -1,7 +1,7 @@
 {
     "area": 280234.5,
-    "extreme_points": [],
-    "interior_points": [],
+    "extreme_points": [0, 1, 2, 3, 21, 22, 23, 24, 25, 30, 31, 32],
+    "interior_points": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 26, 27, 28, 29],
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_1.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 280234.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 33,
     "num_triangles": 31,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 87271,
+    "interior_points": [],
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 87271,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 33,
     "num_triangles": 31,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_12.meta.json
@@ -1,7 +1,7 @@
 {
     "area": 87271,
-    "extreme_points": [],
-    "interior_points": [],
+    "extreme_points": [0, 1, 7, 14, 15, 20, 27],
+    "interior_points": [2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30, 31, 32],
     "num_edges": 33,
     "num_triangles": 31,
     "num_vertices": 33

--- a/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 178124.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 25,
     "num_triangles": 23,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 178124.5,
+    "interior_points": [],
     "num_edges": 25,
     "num_triangles": 23,
     "num_vertices": 25

--- a/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_3.meta.json
@@ -1,7 +1,7 @@
 {
     "area": 178124.5,
-    "extreme_points": [],
-    "interior_points": [],
+    "extreme_points": [0, 4, 8, 9, 10, 11, 20, 21, 24],
+    "interior_points": [1, 2, 3, 5, 6, 7, 12, 13, 14, 15, 16, 17, 18, 19, 22, 23],
     "num_edges": 25,
     "num_triangles": 23,
     "num_vertices": 25

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7a.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7a.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 202986.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 64,
     "num_triangles": 62,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7a.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7a.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 202986.5,
+    "interior_points": [],
     "num_edges": 64,
     "num_triangles": 62,
     "num_vertices": 64

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7b.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7b.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 149592,
+    "interior_points": [],
     "num_edges": 63,
     "num_triangles": 61,
     "num_vertices": 63

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7b.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7b.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 149592,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 63,
     "num_triangles": 61,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7c.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7c.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 58354.5,
+    "interior_points": [],
     "num_edges": 64,
     "num_triangles": 62,
     "num_vertices": 64

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7c.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7c.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 58354.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 64,
     "num_triangles": 62,

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7d.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7d.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 105929,
+    "interior_points": [],
     "num_edges": 61,
     "num_triangles": 59,
     "num_vertices": 61

--- a/computational_geometry/polygons/interesting_polygon_archive/held_7d.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/held_7d.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 105929,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 61,
     "num_triangles": 59,

--- a/computational_geometry/polygons/interesting_polygon_archive/mapbox_building.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mapbox_building.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 2607,
+    "interior_points": [],
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/polygons/interesting_polygon_archive/mapbox_building.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mapbox_building.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 2607,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 15,
     "num_triangles": 13,

--- a/computational_geometry/polygons/interesting_polygon_archive/mapbox_dude.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mapbox_dude.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 15357.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 94,
     "num_triangles": 92,

--- a/computational_geometry/polygons/interesting_polygon_archive/mapbox_dude.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mapbox_dude.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 15357.5,
+    "interior_points": [],
     "num_edges": 94,
     "num_triangles": 92,
     "num_vertices": 94

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_alga.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_alga.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 227168,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 166,
     "num_triangles": 164,

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_alga.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_alga.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 227168,
+    "interior_points": [],
     "num_edges": 166,
     "num_triangles": 164,
     "num_vertices": 166

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_blue.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_blue.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 633616,
+    "interior_points": [],
     "num_edges": 4,
     "num_triangles": 2,
     "num_vertices": 4

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_blue.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_blue.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 633616,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 4,
     "num_triangles": 2,

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_icarus.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_icarus.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 114827,
+    "interior_points": [],
     "num_edges": 83,
     "num_triangles": 81,
     "num_vertices": 83

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_icarus.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_icarus.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 114827,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 83,
     "num_triangles": 81,

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_nuit.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_nuit.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 73799.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 124,
     "num_triangles": 122,

--- a/computational_geometry/polygons/interesting_polygon_archive/matisse_nuit.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/matisse_nuit.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 73799.5,
+    "interior_points": [],
     "num_edges": 124,
     "num_triangles": 122,
     "num_vertices": 124

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_2.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_2.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 229950.5,
+    "interior_points": [],
     "num_edges": 15,
     "num_triangles": 13,
     "num_vertices": 15

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_2.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_2.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 229950.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 15,
     "num_triangles": 13,

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 180013.5,
+    "interior_points": [],
     "num_edges": 42,
     "num_triangles": 40,
     "num_vertices": 42

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 180013.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 42,
     "num_triangles": 40,

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_4.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_4.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 293939,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 69,
     "num_triangles": 67,

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_4.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_4.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 293939,
+    "interior_points": [],
     "num_edges": 69,
     "num_triangles": 67,
     "num_vertices": 69

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_5.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_5.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 270894,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 279,
     "num_triangles": 277,

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_5.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_5.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 270894,
+    "interior_points": [],
     "num_edges": 279,
     "num_triangles": 277,
     "num_vertices": 279

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_6.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_6.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 317640,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 173,
     "num_triangles": 171,

--- a/computational_geometry/polygons/interesting_polygon_archive/mei_6.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/mei_6.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 317640,
+    "interior_points": [],
     "num_edges": 173,
     "num_triangles": 171,
     "num_vertices": 173

--- a/computational_geometry/polygons/interesting_polygon_archive/meisters_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/meisters_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 87090,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 30,
     "num_triangles": 28,

--- a/computational_geometry/polygons/interesting_polygon_archive/meisters_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/meisters_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 87090,
+    "interior_points": [],
     "num_edges": 30,
     "num_triangles": 28,
     "num_vertices": 30

--- a/computational_geometry/polygons/interesting_polygon_archive/misc_discobolus.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/misc_discobolus.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 142911,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 116,
     "num_triangles": 114,

--- a/computational_geometry/polygons/interesting_polygon_archive/misc_discobolus.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/misc_discobolus.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 142911,
+    "interior_points": [],
     "num_edges": 116,
     "num_triangles": 114,
     "num_vertices": 116

--- a/computational_geometry/polygons/interesting_polygon_archive/misc_fu.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/misc_fu.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 320331.5,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 134,
     "num_triangles": 132,

--- a/computational_geometry/polygons/interesting_polygon_archive/misc_fu.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/misc_fu.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 320331.5,
+    "interior_points": [],
     "num_edges": 134,
     "num_triangles": 132,
     "num_vertices": 134

--- a/computational_geometry/polygons/interesting_polygon_archive/seidel_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/seidel_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 227130,
+    "interior_points": [],
     "num_edges": 20,
     "num_triangles": 18,
     "num_vertices": 20

--- a/computational_geometry/polygons/interesting_polygon_archive/seidel_3.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/seidel_3.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 227130,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 20,
     "num_triangles": 18,

--- a/computational_geometry/polygons/interesting_polygon_archive/skimage_horse.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/skimage_horse.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 180144,
+    "interior_points": [],
     "num_edges": 119,
     "num_triangles": 117,
     "num_vertices": 119

--- a/computational_geometry/polygons/interesting_polygon_archive/skimage_horse.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/skimage_horse.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 180144,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 119,
     "num_triangles": 117,

--- a/computational_geometry/polygons/interesting_polygon_archive/toussaint_1a.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/toussaint_1a.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 238110,
+    "extreme_points": [],
     "interior_points": [],
     "num_edges": 125,
     "num_triangles": 123,

--- a/computational_geometry/polygons/interesting_polygon_archive/toussaint_1a.meta.json
+++ b/computational_geometry/polygons/interesting_polygon_archive/toussaint_1a.meta.json
@@ -1,5 +1,6 @@
 {
     "area": 238110,
+    "interior_points": [],
     "num_edges": 125,
     "num_triangles": 123,
     "num_vertices": 125

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -154,6 +154,15 @@ impl Polygon {
         true
     }
 
+    pub fn interior_points(&self) -> HashSet<Point> {
+        todo!("Implement O'Rourke 3.1")
+
+    }
+
+    pub fn exterior_points(&self) -> HashSet<Point> {
+        todo!("Use complement of interior_points to get this one")
+    }
+
     pub fn bounding_box(&self) -> BoundingBox {
         BoundingBox::new(self.min_x(), self.max_x(), self.min_y(), self.max_y())
     }

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -555,9 +555,31 @@ mod tests {
         assert_eq!(
             interior_points, 
             case.metadata.interior_points,
-            "Extra interior: {:?}, Extra extreme: {:?}", 
+            "Extra computed: {:?}, Extra in metadata: {:?}", 
             interior_points.difference(&case.metadata.interior_points),
             case.metadata.interior_points.difference(&interior_points)
+        );
+    }
+
+    #[apply(all_custom_polygons)]
+    #[case::eberly_10(eberly_10())]
+    #[case::eberly_14(eberly_14())]
+    #[case::elgindy_1(elgindy_1())]
+    #[case::gray_embroidery(gray_embroidery())]
+    #[case::held_1(held_1())]
+    #[case::held_12(held_12())]
+    #[case::held_3(held_3())]
+    // TODO could consider combining this test with interior points if
+    // one will always be a complement of the other, but I'm not sure
+    // that will necessarily be the case going forward
+    fn test_extreme_points(#[case] case: PolygonTestCase) {
+        let extreme_points = case.polygon.extreme_points();
+        assert_eq!(
+            extreme_points,
+            case.metadata.extreme_points,
+            "Extra computed: {:?}, Extra in metadata: {:?}", 
+            extreme_points.difference(&case.metadata.extreme_points),
+            case.metadata.extreme_points.difference(&extreme_points)
         );
     }
 

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -182,16 +182,15 @@ impl Polygon {
                         let triangle = Triangle::from_vertices(v1, v2, v3);
 
                         if triangle.contains(p) {
-                            result.insert(id);
+                            // TODO obviously dumb, figure out refs
+                            result.insert(**id);
                             continue;
                         }
                     }
                 }
             }
         }
-        
-        todo!("Implement O'Rourke 3.1")
-
+        result
     }
 
     pub fn exterior_points(&self) -> HashSet<VertexId> {
@@ -327,6 +326,7 @@ mod tests {
     #[derive(Deserialize)]
     struct PolygonMetadata {
         area: f64,
+        interior_points: HashSet<VertexId>,
         num_edges: usize,
         num_triangles: usize,
         num_vertices: usize,
@@ -444,6 +444,14 @@ mod tests {
     #[case::toussaint_1a(toussaint_1a())]
     fn all_polygons(#[case] case: PolygonTestCase) {}
 
+    #[template]
+    #[rstest]
+    #[case::polygon_1(polygon_1())]
+    #[case::polygon_2(polygon_2())]
+    #[case::right_triangle(right_triangle())]
+    #[case::square_4x4(square_4x4())]
+    fn all_custom_polygons(#[case] case: PolygonTestCase) {}
+
 
     #[test]
     #[should_panic]
@@ -536,11 +544,11 @@ mod tests {
         assert_eq!(triangulation_area, case.metadata.area);
     }
 
-    // #[rstest]
-    // #[case::polygon_1(polygon_1(), )]
-    // fn test_interior_points() {
-
-    // }
+    #[apply(all_custom_polygons)]
+    fn test_interior_points(case: PolygonTestCase) {
+        let interior_points = case.polygon.interior_points();
+        assert_eq!(interior_points, case.metadata.interior_points);
+    }
 
     #[apply(all_polygons)]
     fn test_attributes(case: PolygonTestCase) {

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -535,6 +535,15 @@ mod tests {
     #[case::eberly_14(eberly_14())]
     #[case::elgindy_1(elgindy_1())]
     #[case::gray_embroidery(gray_embroidery())]
+    #[case::held_1(held_1())]
+    #[case::held_12(held_12())]
+    #[case::held_3(held_3())]
+    // TODO can add more test cases here, but I've just been going through
+    // and manually verifying they're correct. Some have so many vertices
+    // though it's not practial, and since this is O(n^4) some actually
+    // time out. May make more sense to wait until there's a more tractable
+    // algorithm implmented to test all, and then validate a subset of
+    // fast ones against the long implementation
     fn test_interior_points(#[case] case: PolygonTestCase) {
         let interior_points = case.polygon.interior_points();
         assert_eq!(
@@ -558,6 +567,9 @@ mod tests {
             assert_eq!(
                 num_extreme_points + num_interior_points, 
                 case.metadata.num_vertices,
+            );
+            assert!(
+                case.metadata.extreme_points.is_disjoint(&case.metadata.interior_points)
             );
         }
         // This meta-assert is only valid for polygons without holes, holes 

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -180,7 +180,7 @@ impl Polygon {
         interior_points
     }
 
-    pub fn exterior_points(&self) -> HashSet<VertexId> {
+    pub fn extreme_points(&self) -> HashSet<VertexId> {
         // NOTE: This is currently mad slow O(n^4) since the interior
         // point computation being used has that runtime.
         let ids: HashSet<VertexId> = self.vertex_map.keys().cloned().collect();

--- a/computational_geometry/src/triangle.rs
+++ b/computational_geometry/src/triangle.rs
@@ -1,8 +1,7 @@
 use std::cell::OnceCell;
 
 use crate::{
-    point::Point,
-    vertex::Vertex,
+    line_segment::LineSegment, point::Point, vertex::Vertex
 };
 
 
@@ -22,6 +21,13 @@ impl<'a> Triangle<'a> {
         Triangle::new(&v1.coords, &v2.coords, &v3.coords)
     }
 
+    pub fn to_line_segments(&self) -> Vec<LineSegment> {
+        let ls1 = LineSegment::new(self.p1, self.p2);
+        let ls2 = LineSegment::new(self.p2, self.p3);
+        let ls3 = LineSegment::new(self.p3, self.p1);
+        vec![ls1, ls2, ls3]
+    }
+
     pub fn area(&self) -> f64 {
         *self.area.get_or_init(|| {
             let t1 = (self.p2.x - self.p1.x) * (self.p3.y - self.p1.y);
@@ -32,6 +38,15 @@ impl<'a> Triangle<'a> {
 
     pub fn has_collinear_points(&self) -> bool {
         self.area() == 0.0
+    }
+
+    pub fn contains(&self, p: Point) -> bool {
+        for ls in self.to_line_segments() {
+            if !p.left_on(&ls) {
+                return false;
+            }
+        }
+        true
     }
 }
 

--- a/computational_geometry/src/vertex.rs
+++ b/computational_geometry/src/vertex.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct VertexId(u32);
 
 impl From<u32> for VertexId {
@@ -24,6 +24,12 @@ impl From<usize> for VertexId {
 }
 
 impl fmt::Display for VertexId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for VertexId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/computational_geometry/src/vertex.rs
+++ b/computational_geometry/src/vertex.rs
@@ -1,12 +1,14 @@
 use std::fmt;
 
+use serde::Deserialize;
+
 use crate::{
     line_segment::LineSegment,
     point::Point,
 };
 
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct VertexId(u32);
 
 impl From<u32> for VertexId {

--- a/computational_geometry/src/vertex_map.rs
+++ b/computational_geometry/src/vertex_map.rs
@@ -57,12 +57,22 @@ impl VertexMap {
         v
     }
 
+    pub fn keys(&self) -> hash_map::Keys<'_, VertexId, Vertex> {
+        self.map.keys()
+    }
+
     pub fn values(&self) -> hash_map::Values<'_, VertexId, Vertex> {
         self.map.values()
     }
 
     pub fn values_mut(&mut self) -> hash_map::ValuesMut<'_, VertexId, Vertex> {
         self.map.values_mut()
+    }
+
+    pub fn sorted_ids(&self) -> Vec<&VertexId> {
+        let mut ids: Vec<_> = self.keys().collect();
+        ids.sort();
+        ids
     }
 
     pub fn sorted_vertices(&self) -> Vec<&Vertex> {


### PR DESCRIPTION
Adds an implementation of an $O(n^4)$ algorithm for computing interior points, as well as a method to compute extreme points as a complement of interior points. Also adds several test cases using existing polygon test assets.