### PR TITLE
Add basic benchmarking infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +323,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +404,8 @@ name = "computational_geometry"
 version = "0.1.0"
 dependencies = [
  "assert_approx_eq",
- "itertools",
+ "criterion",
+ "itertools 0.14.0",
  "paste",
  "rstest",
  "rstest_reuse",
@@ -418,10 +483,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "cursor-icon"
@@ -902,6 +1028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,10 +1245,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1546,6 +1702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1803,34 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -1750,6 +1940,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2100,6 +2310,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ My goal for this repo is to eventually have a complete implementation of the alg
 
 ## Benchmarks
 
-Some simple benchmarking capabilities are provided. These are mostly to provide empirical intuition on the runtime of algorithms. Currently only a couple benchmarks are setup, more will be added as more algorithms are implemented.
+Some simple benchmarking capabilities are provided using [Criterion.rs](https://bheisler.github.io/criterion.rs/book/). These are mostly to provide empirical intuition on the runtime of algorithms. Currently only a couple benchmarks are setup, more will be added as more algorithms are implemented.
 
 You can run the benchmarks yourself with
 ```shell
-cargo bench --bench extreme_points interior_points
+cargo bench --bench extreme_points --bench interior_points
 ```
 
 --

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![CLIPPY](https://github.com/adamconkey/computational_geometry/actions/workflows/clippy.yml/badge.svg)
 
 
-Repo for playing around with implementing computational geometry algorithms from scratch in Rust.
+Implementations of computational geometry algorithms from scratch in Rust.
 
 🚧👷‍♂️ **Work In Progress:** This repos is under heavy development right now and just in its nascent stages.
 
@@ -35,7 +35,18 @@ My goal for this repo is to eventually have a complete implementation of the alg
 
 ---
 
-## Running the Visualizer
+## Benchmarks
+
+Some simple benchmarking capabilities are provided. These are mostly to provide empirical intuition on the runtime of algorithms. Currently only a couple benchmarks are setup, more will be added as more algorithms are implemented.
+
+You can run the benchmarks yourself with
+```shell
+cargo bench --bench extreme_points interior_points
+```
+
+--
+
+## Visualizer
 
 A simple visualizer is provided using the [`egui_plot`](https://github.com/emilk/egui_plot) crate. This provides a local webapp to visualize polygons. Currently this is _very_ simple, and just visualizes the polygons themselves as well as a triangulation. Once more algorithms are implemented I plan to add animations so that one can view the different algorithms in action.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ You can run the benchmarks yourself with
 cargo bench --bench extreme_points --bench interior_points
 ```
 
---
+Here is a visualization of one of the benchmarks to compute extreme points, comparing computing them from extreme edges $O(n^3)$ versus computing them from interior points with triangle checks $O(n^4)$:
+
+![Screen Shot 2025-02-02 at 11 51 21 AM](https://github.com/user-attachments/assets/e6550aec-eac0-4413-b6ec-9fd9526c0ae6)
+
+These are both obviously bad algorithms, but they are what is implemented at the moment and provide some basis for comparison.
+
+---
 
 ## Visualizer
 

--- a/computational_geometry/Cargo.toml
+++ b/computational_geometry/Cargo.toml
@@ -24,3 +24,7 @@ path = "src/bin/generate_rotated_ipa_polygons.rs"
 [[bench]]
 name = "extreme_points"
 harness = false
+
+[[bench]]
+name = "interior_points"
+harness = false

--- a/computational_geometry/Cargo.toml
+++ b/computational_geometry/Cargo.toml
@@ -15,6 +15,7 @@ paste = "*"
 rstest = "0.24.0"
 rstest_reuse = "*"
 tempfile = "3.14.0"
+walkdir = "2.5.0"
 
 [[bin]]
 name = "generate-rotated-ipa-polygons"

--- a/computational_geometry/Cargo.toml
+++ b/computational_geometry/Cargo.toml
@@ -3,10 +3,6 @@ name="computational_geometry"
 edition.workspace = true
 version.workspace = true
 
-[[bin]]
-name = "generate-rotated-ipa-polygons"
-path = "src/bin/generate_rotated_ipa_polygons.rs"
-
 [dependencies]
 itertools = "0.14.0"
 serde.workspace = true
@@ -14,7 +10,16 @@ serde_json.workspace = true
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
 paste = "*"
 rstest = "0.24.0"
 rstest_reuse = "*"
 tempfile = "3.14.0"
+
+[[bin]]
+name = "generate-rotated-ipa-polygons"
+path = "src/bin/generate_rotated_ipa_polygons.rs"
+
+[[bench]]
+name = "extreme_points"
+harness = false

--- a/computational_geometry/Cargo.toml
+++ b/computational_geometry/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 itertools = "0.14.0"
 serde.workspace = true
 serde_json.workspace = true
+walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
@@ -15,7 +16,6 @@ paste = "*"
 rstest = "0.24.0"
 rstest_reuse = "*"
 tempfile = "3.14.0"
-walkdir = "2.5.0"
 
 [[bin]]
 name = "generate-rotated-ipa-polygons"

--- a/computational_geometry/benches/extreme_points.rs
+++ b/computational_geometry/benches/extreme_points.rs
@@ -1,0 +1,45 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::{collections::HashMap, path::PathBuf};
+
+use computational_geometry::polygon::Polygon;
+
+
+fn load_polygon(name: &str, folder: &str) -> Polygon {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("polygons");
+    path.push(folder);
+    path.push(format!("{}.json", name));
+    Polygon::from_json(path)
+}
+
+fn polygon_map() -> HashMap<usize, Polygon> {
+    let mut map = HashMap::new();
+    for name in ["polygon_1", "polygon_2", "square_4x4", "right_triangle"].iter() {
+        let p = load_polygon(name, "custom");
+        map.insert(p.num_vertices(), p);
+    }
+    map
+}
+
+fn benchmark_extreme_points(c: &mut Criterion) {
+    let polygon_map = polygon_map();
+    let mut group = c.benchmark_group("Extreme Points");
+
+    for (name, polygon) in polygon_map.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("extreme_points_from_edges", name),
+            polygon, 
+            |b, polygon| b.iter(|| polygon.extreme_points_from_extreme_edges())
+        );
+        group.bench_with_input(
+            BenchmarkId::new("extreme_points_from_interior_points", name), 
+            polygon,
+            |b, polygon| b.iter(|| polygon.extreme_points_from_interior_points())
+        );
+    }
+    group.finish();
+}
+
+
+criterion_group!(benches, benchmark_extreme_points);
+criterion_main!(benches);

--- a/computational_geometry/benches/extreme_points.rs
+++ b/computational_geometry/benches/extreme_points.rs
@@ -4,7 +4,7 @@ use computational_geometry::util::polygon_map_by_num_vertices;
 
 
 fn benchmark_extreme_points(c: &mut Criterion) {
-    let polygon_map = polygon_map_by_num_vertices();
+    let polygon_map = polygon_map_by_num_vertices(200usize);
     let mut group = c.benchmark_group("Extreme Points");
     group.sample_size(10);
 

--- a/computational_geometry/benches/extreme_points.rs
+++ b/computational_geometry/benches/extreme_points.rs
@@ -6,6 +6,7 @@ use computational_geometry::util::polygon_map_by_num_vertices;
 fn benchmark_extreme_points(c: &mut Criterion) {
     let polygon_map = polygon_map_by_num_vertices();
     let mut group = c.benchmark_group("Extreme Points");
+    group.sample_size(10);
 
     for (name, polygon) in polygon_map.iter() {
         group.bench_with_input(

--- a/computational_geometry/benches/extreme_points.rs
+++ b/computational_geometry/benches/extreme_points.rs
@@ -1,29 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use itertools::Itertools;
-use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
-use walkdir::WalkDir;
 
-use computational_geometry::polygon::Polygon;
+use computational_geometry::util::polygon_map_by_num_vertices;
 
-
-fn polygon_map_by_num_vertices() -> HashMap<usize, Polygon> {
-    let mut map = HashMap::new();
-    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    root.push("polygons");
-    let paths = WalkDir::new(root)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .map(|e| e.into_path())
-        .filter(|p| p.is_file())
-        .filter(|p| p.extension() == Some(OsStr::new("json")))
-        // Remove .meta.json files
-        .filter(|p| p.with_extension("").extension() != Some(OsStr::new("meta")));
-    for path in paths.sorted() {
-        let p = Polygon::from_json(path);
-        map.insert(p.num_vertices(), p);
-    }
-    map
-}
 
 fn benchmark_extreme_points(c: &mut Criterion) {
     let polygon_map = polygon_map_by_num_vertices();
@@ -43,7 +21,6 @@ fn benchmark_extreme_points(c: &mut Criterion) {
     }
     group.finish();
 }
-
 
 criterion_group!(benches, benchmark_extreme_points);
 criterion_main!(benches);

--- a/computational_geometry/benches/interior_points.rs
+++ b/computational_geometry/benches/interior_points.rs
@@ -1,0 +1,27 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use computational_geometry::util::polygon_map_by_num_vertices;
+
+
+fn benchmark_interior_points(c: &mut Criterion) {
+    let polygon_map = polygon_map_by_num_vertices();
+    let mut group = c.benchmark_group("Interior Points");
+    group.sample_size(10);
+
+    for (name, polygon) in polygon_map.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("interior_points_from_extreme_edges", name),
+            polygon, 
+            |b, polygon| b.iter(|| polygon.interior_points_from_extreme_edges())
+        );
+        group.bench_with_input(
+            BenchmarkId::new("interior_points_from_triangle_checks", name), 
+            polygon,
+            |b, polygon| b.iter(|| polygon.interior_points_from_triangle_checks())
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_interior_points);
+criterion_main!(benches);

--- a/computational_geometry/benches/interior_points.rs
+++ b/computational_geometry/benches/interior_points.rs
@@ -4,7 +4,7 @@ use computational_geometry::util::polygon_map_by_num_vertices;
 
 
 fn benchmark_interior_points(c: &mut Criterion) {
-    let polygon_map = polygon_map_by_num_vertices();
+    let polygon_map = polygon_map_by_num_vertices(200usize);
     let mut group = c.benchmark_group("Interior Points");
     group.sample_size(10);
 

--- a/computational_geometry/src/lib.rs
+++ b/computational_geometry/src/lib.rs
@@ -12,5 +12,6 @@ pub mod point;
 pub mod polygon;
 pub mod triangle;
 pub mod triangulation;
+pub mod util;
 pub mod vertex;
 pub mod vertex_map;

--- a/computational_geometry/src/polygon.rs
+++ b/computational_geometry/src/polygon.rs
@@ -245,7 +245,7 @@ impl Polygon {
         // NOTE: This is slow O(n^4) since the interior point 
         // computation being used has that runtime.
         let ids = self.vertex_map.ids_set();
-        let interior_ids = self.interior_points();
+        let interior_ids = self.interior_points_from_triangle_checks();
         &ids - &interior_ids
     }
 

--- a/computational_geometry/src/util.rs
+++ b/computational_geometry/src/util.rs
@@ -1,0 +1,25 @@
+use itertools::Itertools;
+use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
+use walkdir::WalkDir;
+
+use crate::polygon::Polygon;
+
+
+pub fn polygon_map_by_num_vertices() -> HashMap<usize, Polygon> {
+    let mut map = HashMap::new();
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("polygons");
+    let paths = WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .map(|e| e.into_path())
+        .filter(|p| p.is_file())
+        .filter(|p| p.extension() == Some(OsStr::new("json")))
+        // Remove .meta.json files
+        .filter(|p| p.with_extension("").extension() != Some(OsStr::new("meta")));
+    for path in paths.sorted() {
+        let p = Polygon::from_json(path);
+        map.insert(p.num_vertices(), p);
+    }
+    map
+}

--- a/computational_geometry/src/util.rs
+++ b/computational_geometry/src/util.rs
@@ -5,7 +5,7 @@ use walkdir::WalkDir;
 use crate::polygon::Polygon;
 
 
-pub fn polygon_map_by_num_vertices() -> HashMap<usize, Polygon> {
+pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> HashMap<usize, Polygon> {
     let mut map = HashMap::new();
     let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     root.push("polygons");
@@ -19,7 +19,9 @@ pub fn polygon_map_by_num_vertices() -> HashMap<usize, Polygon> {
         .filter(|p| p.with_extension("").extension() != Some(OsStr::new("meta")));
     for path in paths.sorted() {
         let p = Polygon::from_json(path);
-        map.insert(p.num_vertices(), p);
+        if p.num_vertices() <= vertex_limit {
+            map.insert(p.num_vertices(), p);
+        }
     }
     map
 }


### PR DESCRIPTION
This change adds basic infrastructure for benchmarking with criterion, including a couple of benchmarks on computing extreme points and interior points. Currently the benchmarks are run on polygons I had laying around for test cases, I expect that will change going forward.